### PR TITLE
Fix repeated teleportation issues & other bugs, for 1.18.1

### DIFF
--- a/src/main/java/dev/the_fireplace/unforgivingvoid/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/dev/the_fireplace/unforgivingvoid/mixin/ServerPlayerEntityMixin.java
@@ -38,7 +38,7 @@ public abstract class ServerPlayerEntityMixin extends PlayerEntity
         DimensionConfig dimensionConfig = DIContainer.get().getInstance(DimensionConfigManager.class).getSettings(this.world.getRegistryKey().getValue());
         if (!this.world.isClient()
             && dimensionConfig.isEnabled()
-            && this.getBlockPos().getY() <= world.getBottomY() - dimensionConfig.getTriggerDistance()
+            && this.getBlockPos().getY() <= getBottomY(world) - dimensionConfig.getTriggerDistance()
             && !isInTeleportationState()
         ) {
             MinecraftServer server = getServer();
@@ -54,6 +54,10 @@ public abstract class ServerPlayerEntityMixin extends PlayerEntity
                 DIContainer.get().getInstance(QueueVoidTransfer.class).queueTransfer((ServerPlayerEntity) (Object) this, server);
             }
         }
+    }
+
+    private int getBottomY(World world) {
+        return world.getBottomY();
     }
 
     @Invoker("getWorld")

--- a/src/main/java/dev/the_fireplace/unforgivingvoid/usecase/SpawnPositionLocator.java
+++ b/src/main/java/dev/the_fireplace/unforgivingvoid/usecase/SpawnPositionLocator.java
@@ -1,10 +1,12 @@
 package dev.the_fireplace.unforgivingvoid.usecase;
 
+
 import dev.the_fireplace.lib.api.teleport.injectables.SafePosition;
 import dev.the_fireplace.unforgivingvoid.UnforgivingVoidConstants;
 import net.minecraft.entity.EntityType;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Box;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.Heightmap;
@@ -24,10 +26,6 @@ public final class SpawnPositionLocator
     @Inject
     public SpawnPositionLocator(SafePosition safePosition) {
         this.safePosition = safePosition;
-    }
-
-    public void setHorizontalOffsetRange(int horizontalOffsetRange) {
-        this.horizontalOffsetRange = horizontalOffsetRange;
     }
 
     public BlockPos findSimilarPosition(EntityType<?> entityType, ServerWorld currentWorld, ServerWorld targetWorld, BlockPos currentPos) {
@@ -58,7 +56,6 @@ public final class SpawnPositionLocator
 
     public BlockPos findSurfacePosition(EntityType<?> entityType, ServerWorld currentWorld, ServerWorld targetWorld, BlockPos currentPos) {
         Optional<Vec3d> spawnVec;
-        Random rand = targetWorld.getRandom();
         BlockPos targetFocalPosition = getDimensionScaledPosition(currentWorld.getRegistryKey(), targetWorld.getRegistryKey(), currentPos);
         int iteration = 0;
         do {
@@ -71,12 +68,8 @@ public final class SpawnPositionLocator
                 );
                 return findSpawnPosition(entityType, targetWorld);
             }
-            int targetX = applyHorizontalOffset(rand, targetFocalPosition.getX());
-            int targetZ = applyHorizontalOffset(rand, targetFocalPosition.getZ());
-            int targetY = targetWorld.getTopY(Heightmap.Type.WORLD_SURFACE, targetX, targetZ);
-            BlockPos attemptPos = new BlockPos(targetX, targetY, targetZ);
 
-            spawnVec = findSafePlatform(entityType, targetWorld, attemptPos);
+            spawnVec = findSafePlatform(entityType, targetWorld, targetFocalPosition);
         } while (spawnVec.isEmpty());
 
         return new BlockPos(spawnVec.get());
@@ -89,15 +82,19 @@ public final class SpawnPositionLocator
         do {
             UnforgivingVoidConstants.getLogger().debug("Attempting to teleport to sky position, iteration {}", iteration);
 
+            int spawnHeight = targetWorld.getChunkManager().getChunkGenerator().getSpawnHeight(targetWorld);
+
             int targetX = applyHorizontalOffset(rand, targetFocalPosition.getX());
             int targetZ = applyHorizontalOffset(rand, targetFocalPosition.getZ());
-            int targetY = targetWorld.getLogicalHeight() - (int) Math.ceil(entityType.getHeight());
+            int targetY = rand.nextInt(targetWorld.getLogicalHeight() - spawnHeight) + spawnHeight - 6 /* minus 6 because bedrock ceiling */;
+
             BlockPos attemptPos = new BlockPos(targetX, targetY, targetZ);
 
             if (isSafeSky(entityType, targetWorld, attemptPos)) {
                 return attemptPos;
             }
         } while (iteration++ < MAX_SCAN_ITERATIONS);
+
         UnforgivingVoidConstants.getLogger().warn(
             "Max attempts exceeded for finding sky position in {}, falling back to finding the spawn position instead.",
             targetWorld.getRegistryKey().getValue().toString()
@@ -107,7 +104,6 @@ public final class SpawnPositionLocator
     }
 
     public BlockPos findSpawnPosition(EntityType<?> entityType, ServerWorld targetWorld) {
-        Random rand = targetWorld.getRandom();
         BlockPos targetFocalPosition = targetWorld.getSpawnPos();
         Optional<Vec3d> spawnVec = findSafePlatform(entityType, targetWorld, targetFocalPosition);
         int iteration = 0;
@@ -122,23 +118,27 @@ public final class SpawnPositionLocator
                 return targetFocalPosition;
             }
 
-            int targetX = applyHorizontalOffset(rand, targetFocalPosition.getX());
-            int targetZ = applyHorizontalOffset(rand, targetFocalPosition.getZ());
-            int targetY = targetWorld.getTopY(Heightmap.Type.WORLD_SURFACE, targetX, targetZ);
-            BlockPos attemptPos = new BlockPos(targetX, targetY, targetZ);
-
-            spawnVec = findSafePlatform(entityType, targetWorld, attemptPos);
+            spawnVec = findSafePlatform(entityType, targetWorld, targetFocalPosition);
         }
 
         return new BlockPos(spawnVec.get());
     }
 
-    private Optional<Vec3d> findSafePlatform(EntityType<?> entityType, ServerWorld targetWorld, BlockPos blockPos) {
-        return safePosition.findBy(entityType, targetWorld, blockPos);
+    private Optional<Vec3d> findSafePlatform(EntityType<?> entityType, ServerWorld targetWorld, BlockPos targetFocalPosition) {
+        Random rand = targetWorld.getRandom();
+
+        int targetX = applyHorizontalOffset(rand, targetFocalPosition.getX());
+        int targetZ = applyHorizontalOffset(rand, targetFocalPosition.getZ());
+        int targetY = targetWorld.getTopY(Heightmap.Type.WORLD_SURFACE, targetX, targetZ);
+        BlockPos attemptPos = new BlockPos(targetX, targetY, targetZ);
+
+        return safePosition.findBy(entityType, targetWorld, attemptPos);
     }
 
     private boolean isSafeSky(EntityType<?> entityType, ServerWorld targetWorld, BlockPos blockPos) {
-        return safePosition.canSpawnInside(entityType, targetWorld.getBlockState(blockPos));
+        Box skySpawnBoundingBox = entityType.createSimpleBoundingBox(blockPos.getX() + 0.5, blockPos.getY(), blockPos.getZ() + 0.5)
+            .withMinY(blockPos.getY() - 16); // minus 16, to guarantee there's always (at least) 16 blocks of space below the player (so they don't spawn on the ground)
+        return targetWorld.isSpaceEmpty(skySpawnBoundingBox);
     }
 
     private BlockPos getDimensionScaledPosition(RegistryKey<World> originDimension, RegistryKey<World> targetDimension, BlockPos inputPos) {
@@ -153,5 +153,9 @@ public final class SpawnPositionLocator
 
     private int applyHorizontalOffset(Random rand, int xzCoordinate) {
         return xzCoordinate - horizontalOffsetRange + rand.nextInt(horizontalOffsetRange * 2);
+    }
+
+    public void setHorizontalOffsetRange(int horizontalOffsetRange) {
+        this.horizontalOffsetRange = horizontalOffsetRange;
     }
 }

--- a/src/main/java/dev/the_fireplace/unforgivingvoid/usecase/SpawnPositionLocator.java
+++ b/src/main/java/dev/the_fireplace/unforgivingvoid/usecase/SpawnPositionLocator.java
@@ -43,12 +43,9 @@ public final class SpawnPositionLocator
                 );
                 return findSpawnPosition(entityType, targetWorld);
             }
-            int targetX = applyHorizontalOffset(rand, targetFocalPosition.getX());
-            int targetZ = applyHorizontalOffset(rand, targetFocalPosition.getZ());
             int targetY = rand.nextInt(targetWorld.getLogicalHeight() - 20) + 10 + targetWorld.getBottomY();
-            BlockPos attemptPos = new BlockPos(targetX, targetY, targetZ);
 
-            spawnVec = findSafePlatform(entityType, targetWorld, attemptPos);
+            spawnVec = findSafePlatform(entityType, targetWorld, targetFocalPosition, targetY);
         } while (spawnVec.isEmpty());
 
         return new BlockPos(spawnVec.get());
@@ -123,6 +120,18 @@ public final class SpawnPositionLocator
 
         return new BlockPos(spawnVec.get());
     }
+
+    private Optional<Vec3d> findSafePlatform(EntityType<?> entityType, ServerWorld targetWorld, BlockPos targetFocalPosition, int targetY) {
+        Random rand = targetWorld.getRandom();
+
+        int targetX = applyHorizontalOffset(rand, targetFocalPosition.getX());
+        int targetZ = applyHorizontalOffset(rand, targetFocalPosition.getZ());
+
+        BlockPos attemptPos = new BlockPos(targetX, targetY, targetZ);
+
+        return safePosition.findBy(entityType, targetWorld, attemptPos);
+    }
+
 
     private Optional<Vec3d> findSafePlatform(EntityType<?> entityType, ServerWorld targetWorld, BlockPos targetFocalPosition) {
         Random rand = targetWorld.getRandom();

--- a/src/main/java/dev/the_fireplace/unforgivingvoid/usecase/VoidTransfer.java
+++ b/src/main/java/dev/the_fireplace/unforgivingvoid/usecase/VoidTransfer.java
@@ -56,7 +56,7 @@ public final class VoidTransfer
 
         Entity teleportedEntity = teleporter.teleport(serverPlayerEntity, targetWorld, spawnPos.getX() + 0.5, spawnPos.getY(), spawnPos.getZ() + 0.5);
 
-        applyStatusEffects(serverPlayerEntity, dimensionConfig);
+        applyStatusEffects((ServerPlayerEntity) teleportedEntity, dimensionConfig);
         createAssistanceMaterials(dimensionConfig, targetWorld, spawnPos);
         UnforgivingVoidConstants.getLogger().debug(
             "Player teleport complete. New position is {}, and new world is {}",

--- a/src/main/java/dev/the_fireplace/unforgivingvoid/usecase/VoidTransfer.java
+++ b/src/main/java/dev/the_fireplace/unforgivingvoid/usecase/VoidTransfer.java
@@ -1,5 +1,6 @@
 package dev.the_fireplace.unforgivingvoid.usecase;
 
+
 import dev.the_fireplace.lib.api.teleport.injectables.Teleporter;
 import dev.the_fireplace.unforgivingvoid.UnforgivingVoidConstants;
 import dev.the_fireplace.unforgivingvoid.config.DimensionConfig;
@@ -22,11 +23,14 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.inject.Inject;
 
+
 public final class VoidTransfer
 {
 
     private final DimensionConfigManager dimensionConfigManager;
+
     private final Teleporter teleporter;
+
     private final SpawnPositionLocator spawnPositionLocator;
 
     @Inject
@@ -41,15 +45,18 @@ public final class VoidTransfer
         DimensionConfig dimensionConfig = dimensionConfigManager.getSettings(currentWorld.getRegistryKey().getValue());
 
         ServerWorld targetWorld = getTargetWorld(server, dimensionConfig);
+
         if (targetWorld == null) {
             UnforgivingVoidConstants.getLogger().error("Target world not found: " + dimensionConfig.getTargetDimension());
             return;
         }
+
         spawnPositionLocator.setHorizontalOffsetRange(dimensionConfig.getHorizontalDistanceOffset());
         BlockPos spawnPos = getSpawnPos(serverPlayerEntity, currentWorld, dimensionConfig, targetWorld);
 
+        Entity teleportedEntity = teleporter.teleport(serverPlayerEntity, targetWorld, spawnPos.getX() + 0.5, spawnPos.getY(), spawnPos.getZ() + 0.5);
+
         applyStatusEffects(serverPlayerEntity, dimensionConfig);
-        Entity teleportedEntity = teleporter.teleport(serverPlayerEntity, targetWorld, spawnPos);
         createAssistanceMaterials(dimensionConfig, targetWorld, spawnPos);
         UnforgivingVoidConstants.getLogger().debug(
             "Player teleport complete. New position is {}, and new world is {}",


### PR DESCRIPTION
Fix #7 for 1.18.1

The `FALL_FROM_SKY` setting had the following issues fixed:
- Would teleport you into blocks
- Did not work properly in the nether

As well as a bug where the effects would not be applied to the client if they were added before teleportation